### PR TITLE
Update ED-Warthog-Target-Script_Addon.cpp

### DIFF
--- a/Send data over TCP to Target/ED-Warthog-Target-Script_Addon.cpp
+++ b/Send data over TCP to Target/ED-Warthog-Target-Script_Addon.cpp
@@ -35,7 +35,7 @@ int main()
 	std::string jsonStr_Backup;
 
 	//Create a buffer where FileReadStream can store the data 
-	char readBuffer[256];
+	char readBuffer[512];   //[DM] status.json length often exceeds 256.
 
 	LOOP:for (;;) {
 


### PR DESCRIPTION
Increase readBuffer size to 512 to cater for status.json length now often exceeding 256 characters