### PR TITLE
Update ED-Warthog-Target-Script_Addon.cpp

### DIFF
--- a/Send data over TCP to Target/ED-Warthog-Target-Script_Addon.cpp
+++ b/Send data over TCP to Target/ED-Warthog-Target-Script_Addon.cpp
@@ -88,7 +88,8 @@ int main()
 			int v_Flags = 0;
 			if (status.HasMember("Flags")) {
 				assert(status["Flags"].IsNumber()); //Flags
-				v_Flags = status["Flags"].GetInt();
+//				v_Flags = status["Flags"].GetInt();
+				v_Flags = status["Flags"].GetUint();
 				//printf("Flags = %d\n", v_Flags);
 			}
 


### PR DESCRIPTION
Signed integers throw an exception error when srvHighBeam is set (bit 31).
Use unsigned integer instead.